### PR TITLE
Use xsd:integer instead of xsd:decimal for contao:groups

### DIFF
--- a/schema/index.jsonld
+++ b/schema/index.jsonld
@@ -16,7 +16,7 @@
         },
         "groups": {
             "@id": "contao:groups",
-            "@type": "xsd:decimal"
+            "@type": "xsd:integer"
         },
         "fePreview": {
             "@id": "contao:fePreview",


### PR DESCRIPTION
Not sure if this is correct, but shouldn't we use `xsd:integer` for the group IDs? They will never be decimals.